### PR TITLE
add isDuplicated function to remove nested border in comment,optimize…

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -146,7 +146,9 @@ function convertTree(parent) {
                         parent.style.setProperty("font-family", "lucida grande,tahoma,verdana,arial,sans-serif", "important");
                         if (font_verification_enable) {
                             var parentElement = findParent(parent);
-                            parentElement.classList.add("i_am_zawgyi");
+                            if(isDuplicated(parentElement)===false){
+                                parentElement.classList.add("i_am_zawgyi");
+                            }
                         } else {
                             addNoti();
                         }
@@ -172,7 +174,16 @@ function findParent(element){
             end = true;
         }
     }
+    if(parentElement.nodeName == 'SPAN'){
+        parentElement.style.display = 'block';
+    } else if(parentElement.nodeName == 'A'){
+        parentElement.style.display = 'inline-block';
+    }
     return parentElement;
+}
+function isDuplicated(element){
+    var parent = findParent(element);
+    return parent.className.indexOf('i_am_zawgyi')!==-1 ? true : false ;
 }
 var addObserver = function() {
     var MutationObserver = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;

--- a/manifest.json
+++ b/manifest.json
@@ -29,8 +29,5 @@
    } ],
   "permissions": [
     "activeTab", "storage"
-  ],
-  "web_accessible_resources": [
-       "icon19.png"
-     ]
+  ]
 }

--- a/zawgyi.css
+++ b/zawgyi.css
@@ -1,9 +1,6 @@
 @keyframes changecolorhover {
-    from {
-        border-left: 3px solid rgba(247, 247, 247 , 1);
-    }
     to {
-        border-left: 3px solid rgba(253, 17, 0 , 1);
+        border-left: 4px solid #FD1100;
     }
 }
 
@@ -13,10 +10,9 @@
     animation-timing-function: linear;
     animation-iteration-count: infinite;
     animation-direction: alternate;
-    cursor: url('chrome-extension://__MSG_@@extension_id__/icon19.png'),auto;
 }
 .i_am_zawgyi {
-    border-left: 3px solid rgba(247, 247, 247 , 1);
+    border-left: 4px solid #DDDFE2;
     padding-left: .6em;
 }
 /* CSS copied from https://github.com/CodeSeven/toastr */


### PR DESCRIPTION
…  parentElement Finder Function for comment,remove mua cursor
အရင်တုန်းက မှတ်ချက်တွေမှာ ဘော်ဒါလိုင်းတိုပါတယ်။ အဲ့အတွက် ဇော်ဂျီနဲ့ ရေးတာကို ခွဲရတာ ခက်ပါတယ်။ အခု တော့ မှတ်ချက်တွေမှာ ဘော်ဒါလိုင်းမတိုအောင် parent Element Finder function ကို ပြင်ထားပါတယ်။နောက်ပြီးတော့ မှတ်ချက်တွေမှာ ဘော်ဒါ နှစ်ကြောင်းမထပ်အောင် isDuplicated ဖန်ရှင် အသစ်တစ်ခု ထည့်ထားပါတယ်။
link တွေမှာ နောက်တစ်လိုင်းဆင်းသွားတာကိုလည်း မဆင်းအောင်ပြင်ထားပါတယ်။ 
MUA Cursor ကိုပြန်ဖြုတ်ထားပါတယ်။ အခုဗားရှင်းမှာ မှတ်ချက်တွေအစ ဇော်ဂျီနဲ့ ရေးထားတယ် ဆိုတာကို ထင်ရှားရှားခွဲနိုင်လာပါတယ်။
![image](https://cloud.githubusercontent.com/assets/9404824/16016740/789a624a-31c2-11e6-8276-3466f79cdda8.png)
